### PR TITLE
Chart Editor tweak + organization

### DIFF
--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -2734,8 +2734,7 @@ class ChartingState extends MusicBeatState
 				{
 					FlxG.sound.music.pause();
 					pauseVocals();
-					lilBf.animation.play("idle");
-					lilOpp.animation.play("idle");
+					resetBuddies();
 					lilBf.color = lilOpp.color = FlxColor.WHITE;
 					if (idleMusic != null && idleMusic.music != null && idleMusicAllow) idleMusic.unpauseMusic(2);
 				}
@@ -2749,8 +2748,7 @@ class ChartingState extends MusicBeatState
 						if(opponentVocals != null) opponentVocals.play();
 					}
 					if (idleMusic != null && idleMusic.music != null && idleMusicAllow) idleMusic.pauseMusic();
-					lilBf.animation.play("idle");
-					lilOpp.animation.play("idle");
+					resetBuddies();
 					lilBf.color = lilOpp.color = FlxColor.WHITE;
 				}
 			}
@@ -2788,8 +2786,7 @@ class ChartingState extends MusicBeatState
 			{
 				if (idleMusic != null && idleMusic.music != null && idleMusicAllow) idleMusic.unpauseMusic(2);
 				FlxG.sound.music.pause();
-				lilBf.animation.play("idle");
-				lilOpp.animation.play("idle");
+				resetBuddies();
 				lilBf.color = lilOpp.color = FlxColor.WHITE;
 				if (!mouseQuant)
 					FlxG.sound.music.time -= (FlxG.mouse.wheel * Conductor.stepCrochet*0.8);
@@ -2814,8 +2811,7 @@ class ChartingState extends MusicBeatState
 			if (FlxG.keys.pressed.W || FlxG.keys.pressed.S)
 			{
 				if (idleMusic != null && idleMusic.music != null && idleMusicAllow) idleMusic.unpauseMusic(2);
-				lilBf.animation.play("idle");
-				lilOpp.animation.play("idle");
+				resetBuddies();
 				lilBf.color = lilOpp.color = FlxColor.WHITE;
 				FlxG.sound.music.pause();
 
@@ -3109,6 +3105,11 @@ class ChartingState extends MusicBeatState
 		lastConductorPos = Conductor.songPosition;
 		super.update(elapsed);
 		idleMusic.update(elapsed);
+	}
+
+	function resetBuddies() {
+		lilBf.animation.play("idle");
+		lilOpp.animation.play("idle");
 	}
 
 	function updateZoom() {
@@ -3424,6 +3425,8 @@ class ChartingState extends MusicBeatState
 
 	function resetSection(songBeginning:Bool = false):Void
 	{
+		resetBuddies();
+
 		updateGrid((songBeginning ? true : false));
 
 			if (FlxG.sound.music.playing && idleMusic != null && idleMusic.music != null && idleMusicAllow) idleMusic.pauseMusic();
@@ -3449,8 +3452,7 @@ class ChartingState extends MusicBeatState
 		if (_song.notes[sec] != null)
 		{
 			if (FlxG.sound.music.playing && idleMusic != null && idleMusic.music != null && idleMusicAllow) idleMusic.pauseMusic();
-			lilBf.animation.play("idle");
-			lilOpp.animation.play("idle");
+			resetBuddies();
 			lilBf.color = lilOpp.color = FlxColor.WHITE;
 			curSec = sec;
 			if (updateMusic)


### PR DESCRIPTION
1. fixed a bug with the lil' opp/bf not resetting immediately to "idle" after pressing "R" in chart editor

2. combine the "playAnim = idle" code into a single function, to remove duplicate functions

here's a video that understands what i mean:
https://github.com/user-attachments/assets/d94ccbb3-61bc-4dae-a7ae-506276a63835

another pull request in 1 day wtf-