### PR TITLE
Added a warning about `git clone` with branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 README.md revamped by [Nael2xd](https://youtube.com/@nael2xd?si=axwJrY_8jdlXUwSm)
 
+<b>IMPORTANT: if you want to clone the repo (for making a pull request or for building locally), use <code>git clone -b main --single-branch https://github.com/JordanSantiagoYT/FNF-JS-Engine.git</code> so you only git clone _only the main branch_, the other ones are for experiments or are extremely old.</b>
+
 <!-- _If you're looking for the Mobile port, [go here](https://github.com/JordanSantiagoYT/FNF-JS-Engine/tree/mobile)._ -->
 
 ## Welcome


### PR DESCRIPTION
Adds a warning about how git will download EVERY branch when git cloning, even if you just want to make a quick patch on the main branch:

<b>IMPORTANT: if you want to clone the repo (for making a pull request or for building locally), use <code>git clone -b main --single-branch https://github.com/JordanSantiagoYT/FNF-JS-Engine.git</code> so you only git clone _only the main branch_, the other ones are for experiments or are extremely old.</b>